### PR TITLE
local-status now returns an sexp with pkg names and a alist

### DIFF
--- a/cyclone-winds.scm
+++ b/cyclone-winds.scm
@@ -145,12 +145,13 @@
   (let ((index (get-local-index)))
     (if (null? index)
         (display (format "None~%"))
-        (for-each
-         (lambda (pkg)
-           (display
-            (format "~%  ~a  Version: ~a  Cyclone: ~a~%  Libraries: ~a~%  Programs:  ~a~%"
-                    (car pkg) (cadr pkg) (caddr pkg) (cadddr pkg) (cadddr (cdr pkg)))))
-         index))))
+        (pretty-print (map (lambda (pkg)
+                             `(,(car pkg)
+                               (version . ,(cadr pkg))
+                               (cyclone . ,(caddr pkg))
+                               (libraries . ,(cadddr pkg))
+                               (programs . ,(cadddr (cdr pkg)))))
+                           index)))))
 
 (define (index)
   (pretty-print (get-index)))


### PR DESCRIPTION
@justinethier, I thought I would be able to also implement the lock mechanism, but I won't have time to finish it today. I propose we do release Cyclone `0.18` with `cyclone-winds` as provided by the this and the `modularize` branch and we improve it on later versions - what do you think? 

Thanks for the opportunity to contribute!