### PR TITLE
Fixed (really?) all calls to unclosed ports

### DIFF
--- a/libs/index.sld
+++ b/libs/index.sld
@@ -37,10 +37,8 @@
         (make-dir! tmp-dir)
         (display (format "Retrieving index file...~%"))
         (download! *default-index-url* index-path)
-        (let* ((index-port (open-input-file index-path))
-               (content (cdr (read index-port))))
+        (let* ((content (cdr (with-input-from-file index-path (lambda () (read))))))
           (delete! tmp-dir)
-          (close-port index-port)
           content)))
 
     (define (pkg-info index name/maybe-version)

--- a/libs/package.sld
+++ b/libs/package.sld
@@ -95,10 +95,8 @@
              (metadata-path (->path work-dir *default-metadata-file*)))
         (make-dir! work-dir)
         (download! metadata-url metadata-path)
-        (let* ((metadata-port (open-input-file metadata-path))
-               (metadata (read metadata-port)))
+        (let ((metadata (with-input-from-file metadata-path (lambda () (read)))))
           (delete! work-dir)
-          (close-port metadata-port)
           metadata)))
 
     (define (build-and-install pkg . dir)
@@ -403,11 +401,9 @@
         (let-values (((sld-files scm-files) (find-code-files-recursively work-dir)))
           (let* ((libs+defs+incls
                   (map (lambda (sld)
-                         (let* ((sld-port (open-input-file sld))
-                                (content (read sld-port))
+                         (let* ((content (with-input-from-file sld (lambda () (read))))
                                 (lib-name (lib:name content))
                                 (include-dir (cdr (reverse (cdr (reverse lib-name))))))
-                           (close-port sld-port)
                            (list lib-name
                                  (filter-exported-defines
                                   (lib:exports content)

--- a/sys/tasks.scm
+++ b/sys/tasks.scm
@@ -18,12 +18,13 @@
 (include "sys/update-library-index.scm")
 
 (define (file->string file)
-  (define file-port (open-input-file file))
-  (let lp ((content ""))
-    (let ((r (read-line file-port)))
-      (if (eof-object? r)
-          (string-copy content (min (string-length content) 1)) ; hack to remove first "\n"
-          (lp (string-append content "\n" r))))))
+  (with-input-from-file file
+    (lambda ()
+      (let lp ((content ""))
+        (let ((r (read-line)))
+          (if (eof-object? r)
+              (string-copy content (min (string-length content) 1)) ; hack to remove first "\n"
+              (lp (string-append content "\n" r))))))))
 
 (define (srfi? pkg)
   (string-contains (->string pkg) "srfi"))

--- a/sys/update-library-index.scm
+++ b/sys/update-library-index.scm
@@ -4,7 +4,7 @@
   (let ((work-dir (->path pkg-name (*default-code-directory*))))
     (let-values (((sld-files _) (find-code-files-recursively work-dir)))
       (map (lambda (sld)
-             (let ((content (read (open-input-file sld))))
+             (let ((content (with-input-from-file sld (lambda () (read)))))
                (list (lib:name content) (lib:exports content))))
            sld-files))))
 
@@ -18,6 +18,7 @@
     (set! library-index (append library-index (list (list pkg-name lib+exps))))))
 
 (define (write-library-index!) 
-  (pretty-print library-index
-                (open-output-file *default-library-index*)))
+  (with-output-to-file *default-library-index*
+    (lambda ()
+      (pretty-print library-index))))
 

--- a/sys/update-packages-wiki.scm
+++ b/sys/update-packages-wiki.scm
@@ -48,5 +48,6 @@
                                       wiki-separator))
                       (else
                        (string-append wiki-header doc wiki-separator)))))
-          (display wiki-new-content (open-output-file wiki-file-path))
+          (with-output-to-file wiki-file-path
+            (lambda () (display wiki-new-content)))
           (display (format "Wiki of package ~a updated.~%" pkg-name))))))

--- a/sys/update-wiki-index.scm
+++ b/sys/update-wiki-index.scm
@@ -15,7 +15,7 @@ Packages available:\n
 (define (get-info-row pkg-name)
   (let* ((work-dir (->path "." pkg-name))
          (md-path (->path work-dir *default-metadata-file*))
-         (pkg (metadata->pkg (cdr (read (open-input-file md-path))))))
+         (pkg (metadata->pkg (cdr (with-input-from-file md-path (lambda () (read)))))))
     (string-append "|"
                    (string-join (list (let ((name (->string (get-name pkg))))
                                         (string-append "[" name "](" *default-wiki-url* name ")"))
@@ -37,5 +37,6 @@ Packages available:\n
     (set! wiki-index (string-append wiki-index info-row))))
 
 (define (write-wiki-index!) 
-  (display (string-append home-header wiki-index home-footer)
-           (open-output-file *default-wiki-home-file*)))
+  (with-output-to-file *default-wiki-home-file*
+    (lambda ()
+      (display (string-append home-header wiki-index home-footer)))))

--- a/winds.scm
+++ b/winds.scm
@@ -26,9 +26,8 @@
   (let* ((work-dir (if (null? dir) "." (->path (car dir))))
          (pkg
           (validate-metadata
-           (read
-            (open-input-file (->path work-dir
-                                     *default-metadata-file*)))))
+           (with-input-from-file (->path work-dir *default-metadata-file*)
+             (lambda () (read)))))
          (test-dependencies (get-test-dependencies pkg))
          (test-file (get-test pkg)))
     (and test-dependencies
@@ -52,9 +51,8 @@
   (let* ((work-dir (if (null? dir) "." (->path (car dir))))
          (pkg
           (validate-metadata
-           (read
-            (open-input-file (->path work-dir
-                                     *default-metadata-file*))))))
+           (with-input-from-file (->path work-dir *default-metadata-file*)
+             (lambda () (read))))))
     (let ((progs (get-programs-names pkg))
           (libs (get-libraries-names pkg)))
       (and libs (build-libraries libs work-dir))          
@@ -65,7 +63,7 @@
          (metadata-path (->path work-dir *default-metadata-file*))
          (pkg (if (file-exists? metadata-path)
                   ;; reads 'package.scm' skipping the initial (package ...) tag
-                  (let ((md (cdr (read (open-input-file metadata-path))))) 
+                  (let ((md (cdr (with-input-from-file metadata-path (lambda () (read)))))) 
                     (copy-file! metadata-path (string-append metadata-path ".old")) ;; backup old one
                     (delete! metadata-path)
                     (metadata->pkg md))


### PR DESCRIPTION
Finished the job of issue #27.

Could you please check it again, @justinethier? I also made calls to files homogeneous by using `with-input-from-file` and `with-output-to-file` instead of `open-input-file` and `open-output-file`, respectively.

Thanks for the hint of the incomplete job :)